### PR TITLE
Refactor controllers to separate admin and user responsibilities

### DIFF
--- a/src/main/kotlin/com/cornerstone/cheque/auth/SecurityConfig.kt
+++ b/src/main/kotlin/com/cornerstone/cheque/auth/SecurityConfig.kt
@@ -4,53 +4,45 @@ import com.cornerstone.cheque.auth.jwt.JwtAuthenticationFilter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.authentication.AuthenticationManager
-import org.springframework.security.authentication.AuthenticationProvider
-import org.springframework.security.authentication.dao.DaoAuthenticationProvider
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
-import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
 @Configuration
 @EnableMethodSecurity
-@EnableWebSecurity
-class SecurityConfig(
-    private val jwtAuthFilter: JwtAuthenticationFilter,
-    private val userDetailsService: UserDetailsService
-) {
+class SecurityConfig(private val jwtAuthenticationFilter: JwtAuthenticationFilter) {
+
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
-        return http.csrf { it.disable() }
-            .authorizeHttpRequests {
-                it.requestMatchers("/api/auth/**").permitAll()
+        http
+            .csrf { it.disable() }
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .authorizeHttpRequests { authorize ->
+                authorize
+                    .requestMatchers("/api/auth/**").permitAll()
+                    .requestMatchers("/api/admin/**").hasRole("ADMIN")
                     .anyRequest().authenticated()
             }
-            .sessionManagement {
-                it.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-            }
-            .authenticationProvider(authenticationProvider())
-            .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter::class.java)
-            .build()
+            .addFilterBefore(
+                jwtAuthenticationFilter,
+                org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter::class.java
+            )
+
+        return http.build()
     }
 
     @Bean
-    fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()
-
-    @Bean
-    fun authenticationManager(config: AuthenticationConfiguration): AuthenticationManager =
-        config.authenticationManager
-
-    @Bean
-    fun authenticationProvider(): AuthenticationProvider {
-        val provider = DaoAuthenticationProvider()
-        provider.setUserDetailsService(userDetailsService)
-        provider.setPasswordEncoder(passwordEncoder())
-        return provider
+    fun passwordEncoder(): PasswordEncoder {
+        return BCryptPasswordEncoder()
     }
+
+    @Bean
+    fun authenticationManager(authConfig: AuthenticationConfiguration): AuthenticationManager {
+        return authConfig.authenticationManager
+    }
+
 }

--- a/src/main/kotlin/com/cornerstone/cheque/auth/jwt/AuthenticationController.kt
+++ b/src/main/kotlin/com/cornerstone/cheque/auth/jwt/AuthenticationController.kt
@@ -24,7 +24,7 @@ class AuthenticationController(
             val user = userRepository.findByEmail(request.email)
                 ?: throw UsernameNotFoundException("User not found")
 
-            val token = jwtService.generateToken(request.email)
+            val token = jwtService.generateToken(request.email, user.role.name)
             return ResponseEntity.ok(AuthResponse(token))
         } else {
             throw UsernameNotFoundException("Invalid credentials")

--- a/src/main/kotlin/com/cornerstone/cheque/auth/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/cornerstone/cheque/auth/jwt/JwtAuthenticationFilter.kt
@@ -31,6 +31,12 @@ class JwtAuthenticationFilter(
 
         if (jwtService.isTokenValid(token) && SecurityContextHolder.getContext().authentication == null) {
             val username = jwtService.extractUsername(token)
+            val role = jwtService.extractRole(token)
+
+            if (request.requestURI.startsWith("/api/admin") && role != "ADMIN") {
+                response.sendError(HttpServletResponse.SC_FORBIDDEN, "Admin access required")
+                return
+            }
 
             val userDetails = userDetailsService.loadUserByUsername(username)
 

--- a/src/main/kotlin/com/cornerstone/cheque/auth/jwt/JwtService.kt
+++ b/src/main/kotlin/com/cornerstone/cheque/auth/jwt/JwtService.kt
@@ -16,12 +16,13 @@ class JwtService(
     private val secretKey: SecretKey = Keys.hmacShaKeyFor(jwtSecret.encodeToByteArray())
     private val expirationMs: Long = 1000 * 60 * 60 * 24
 
-    fun generateToken(username: String): String {
+    fun generateToken(username: String,  role: String): String {
         val now = Date()
         val expiry = Date(now.time + expirationMs)
 
         return Jwts.builder()
             .setSubject(username)
+            .claim("role", role)
             .setIssuedAt(now)
             .setExpiration(expiry)
             .signWith(secretKey)
@@ -44,4 +45,13 @@ class JwtService(
             false
         }
     }
+
+    fun extractRole(token: String): String =
+        Jwts.parserBuilder()
+            .setSigningKey(secretKey)
+            .build()
+            .parseClaimsJws(token)
+            .body
+            .get("role", String::class.java)
+
 }

--- a/src/main/kotlin/com/cornerstone/cheque/controller/AccountController.kt
+++ b/src/main/kotlin/com/cornerstone/cheque/controller/AccountController.kt
@@ -1,48 +1,33 @@
 package com.cornerstone.cheque.controller
 
-import com.cornerstone.cheque.model.Account
 import com.cornerstone.cheque.model.AccountRequest
 import com.cornerstone.cheque.model.AccountResponse
-import com.cornerstone.cheque.repo.AccountRepository
 import com.cornerstone.cheque.service.AccountService
 import com.cornerstone.cheque.service.UserService
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
 import java.security.Principal
-import java.time.LocalDateTime
 
-@PreAuthorize("hasRole('ADMIN')")
 @RestController
 @RequestMapping("/api/accounts")
 class AccountController(
     private val accountService: AccountService,
     private val userService: UserService
 ) {
-    @PreAuthorize("hasAnyRole('USER','ADMIN')")
+    @PreAuthorize("hasRole('USER','ADMIN')")
     @PostMapping("/create")
     fun createAccount(@RequestBody request: AccountRequest, principal: Principal): ResponseEntity<Any> {
-        val user = userService.findByUsername(principal.name)
+        val user = userService.findByEmail(principal.name)
             ?: throw IllegalStateException("User not authenticated")
         val userId = user.id ?: throw IllegalStateException("User ID missing")
         return ResponseEntity.ok(accountService.create(userId, request))
     }
 
-    @GetMapping("/getAll")
-    fun getAll(): ResponseEntity<List<AccountResponse>> =
-        ResponseEntity.ok(accountService.getAll())
-
-    @GetMapping("/{accountNumber}")
-    fun getByAccountNumber(@PathVariable accountNumber: String): ResponseEntity<AccountResponse> {
-        val result = accountService.getByAccountNumber(accountNumber)
-            ?: throw IllegalArgumentException("Account not found")
-        return ResponseEntity.ok(result)
-    }
-
-    @PreAuthorize("hasAnyRole('USER','ADMIN')")
+    @PreAuthorize("hasRole('USER','ADMIN')")
     @GetMapping("/my")
     fun getMyAccounts(principal: Principal): ResponseEntity<List<AccountResponse>> {
-        val user = userService.findByUsername(principal.name)
+        val user = userService.findByEmail(principal.name)
             ?: throw IllegalStateException("User not authenticated")
         return ResponseEntity.ok(accountService.getByUserId(user.email))
     }

--- a/src/main/kotlin/com/cornerstone/cheque/controller/AdminController.kt
+++ b/src/main/kotlin/com/cornerstone/cheque/controller/AdminController.kt
@@ -1,0 +1,165 @@
+package com.cornerstone.cheque.controller
+
+import com.cornerstone.cheque.model.*
+import com.cornerstone.cheque.repo.AccountRepository
+import com.cornerstone.cheque.repo.UserRepository
+import com.cornerstone.cheque.service.*
+import jakarta.validation.constraints.NotNull
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.*
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+@RestController
+@RequestMapping("/api/admin")
+@PreAuthorize("hasRole('ADMIN')")
+class AdminController(
+    private val userService: UserService,
+    private val redeemService: RedeemService,
+    private val transactionService: TransactionService,
+    private val kycService: KYCService,
+    private val userRepository: UserRepository,
+    private val accountService: AccountService,
+    private val accountRepository: AccountRepository,
+    private val paymentLinkService: PaymentLinkService,
+    private val transferService: TransferService
+) {
+
+    data class DashboardStats(
+        val totalUsers: Long,
+        val totalTransactions: Int,
+        val growthPercentage: Double,
+        val lastUpdated: LocalDateTime
+    )
+
+    @GetMapping("/dashboard")
+    fun getDashboardStats(): ResponseEntity<DashboardStats> {
+        val totalUsers = userService.getTotalUsers()
+        val totalTransactions = transactionService.getTotalTransactionAmount()
+        val growthPercentage = calculateGrowth()
+        val lastUpdated = LocalDateTime.now()
+
+        return ResponseEntity.ok(
+            DashboardStats(totalUsers, totalTransactions, growthPercentage, lastUpdated)
+        )
+    }
+
+    @GetMapping("/users")
+    fun getUsers(
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "10") size: Int,
+        @RequestParam(required = false) role: String?
+    ): ResponseEntity<Any> {
+        val users = userService.getUsers(page, size, role)
+        return ResponseEntity.ok(users)
+    }
+
+    @GetMapping("/users/{userId}")
+    fun getUserById(@PathVariable userId: Long): ResponseEntity<User> =
+        ResponseEntity.ok(userService.getUserById(userId))
+
+    @DeleteMapping("/users/{userId}")
+    fun deleteUser(@PathVariable userId: Long): ResponseEntity<Void> {
+        val user = userService.getUserById(userId)
+        if (user.role == Role.ADMIN) throw IllegalStateException("Cannot delete admin users")
+        userService.deleteUser(userId)
+        return ResponseEntity.ok().build()
+    }
+
+    @PostMapping("/users/{userId}/reset-password")
+    fun resetPassword(@PathVariable userId: Long): ResponseEntity<String> =
+        ResponseEntity.ok(userService.resetPassword(userId))
+
+    @PostMapping("/users/{userId}/suspend")
+    fun suspendUser(@PathVariable userId: Long): ResponseEntity<Void> {
+        userService.suspendUser(userId)
+        return ResponseEntity.ok().build()
+    }
+
+    @GetMapping("/redeem/active/count")
+    fun getActiveCodeCount(): ResponseEntity<Any> {
+        val count = redeemService.countActiveCodes()
+        return ResponseEntity.ok(mapOf("activeCodes" to count))
+    }
+
+    @PostMapping("/redeem/generate")
+    fun generateCode(@RequestBody request: RedeemRequest): ResponseEntity<Any> {
+        val code = redeemService.generate(request.amount)
+        return ResponseEntity.ok(mapOf("code" to code.code, "amount" to code.amount))
+    }
+
+    @GetMapping("/kyc/getAll")
+    fun getAllKYC(): ResponseEntity<List<KYC>> =
+        ResponseEntity.ok(kycService.getAll())
+
+    @GetMapping("/kyc/{id}")
+    fun getKYCById(@PathVariable id: Long): ResponseEntity<KYC> =
+        ResponseEntity.ok(kycService.getById(id) ?: throw IllegalArgumentException("KYC not found"))
+
+    @GetMapping("/accounts/getAll")
+    fun getAllAccounts(): ResponseEntity<List<AccountResponse>> =
+        ResponseEntity.ok(accountService.getAll())
+
+    @GetMapping("/accounts/{accountNumber}")
+    fun getAccountByNumber(@PathVariable accountNumber: String): ResponseEntity<AccountResponse> {
+        val result = accountService.getByAccountNumber(accountNumber)
+            ?: throw IllegalArgumentException("Account not found")
+        return ResponseEntity.ok(result)
+    }
+
+    @GetMapping("/transactions/getAll")
+    fun getAllTransactions(): ResponseEntity<List<TransactionResponse>> =
+        ResponseEntity.ok(transactionService.getAll().map {
+            TransactionResponse(
+                id = it.id,
+                senderAccountNumber = it.senderAccount.accountNumber,
+                receiverAccountNumber = it.receiverAccount.accountNumber,
+                amount = it.amount,
+                createdAt = it.createdAt
+            )
+        })
+
+    @GetMapping("/payment-links/getAll")
+    fun getAllPaymentLinks() =
+        ResponseEntity.ok(paymentLinkService.getAll().map { paymentLinkService.toResponse(it) })
+
+    @GetMapping("/payment-links/{id}")
+    fun getPaymentLinkById(@PathVariable id: Long): ResponseEntity<PaymentLinkResponse> =
+        ResponseEntity.ok(paymentLinkService.getResponseById(id))
+
+    @DeleteMapping("/payment-links/{id}")
+    fun deletePaymentLink(@PathVariable id: Long): ResponseEntity<Void> {
+        paymentLinkService.delete(id)
+        return ResponseEntity.noContent().build()
+    }
+
+    @GetMapping("/transfers/getAll")
+    fun getAllTransfers(): ResponseEntity<List<TransferResponse>> =
+        ResponseEntity.ok(transferService.getAll())
+
+    private fun calculateGrowth(): Double = 24.8
+}
+
+data class RedeemRequest(
+    @NotNull
+    val amount: BigDecimal
+)
+
+data class PaymentLinkResponse(
+    val id: Long,
+    val accountNumber: String,
+    val amount: BigDecimal,
+    val description: String,
+    val status: String,
+    val transactionId: Long?,
+    val uuid: String
+)
+
+data class TransactionResponse(
+    val id: Long,
+    val senderAccountNumber: String,
+    val receiverAccountNumber: String,
+    val amount: BigDecimal,
+    val createdAt: LocalDateTime
+)

--- a/src/main/kotlin/com/cornerstone/cheque/controller/KYCController.kt
+++ b/src/main/kotlin/com/cornerstone/cheque/controller/KYCController.kt
@@ -2,7 +2,6 @@ package com.cornerstone.cheque.controller
 
 import com.cornerstone.cheque.model.KYC
 import com.cornerstone.cheque.model.KYCRequest
-import com.cornerstone.cheque.repo.KYCRepository
 import com.cornerstone.cheque.repo.UserRepository
 import com.cornerstone.cheque.service.KYCService
 import org.springframework.http.ResponseEntity
@@ -10,14 +9,13 @@ import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
 import java.security.Principal
 
-@PreAuthorize("hasRole('ADMIN')")
 @RestController
 @RequestMapping("/api/kyc")
 class KYCController(
     private val service: KYCService,
     private val userRepository: UserRepository
 ) {
-    @PreAuthorize("hasAnyRole('USER','ADMIN')")
+    @PreAuthorize("hasRole('USER','ADMIN')")
     @PostMapping
     fun create(@RequestBody request: KYCRequest, principal: Principal): ResponseEntity<KYC> {
         val user = userRepository.findByEmail(principal.name)
@@ -26,15 +24,7 @@ class KYCController(
         return ResponseEntity.ok().build()
     }
 
-    @GetMapping("getAll")
-    fun getAll(): ResponseEntity<List<KYC>> =
-        ResponseEntity.ok(service.getAll())
-
-    @GetMapping("/{id}")
-    fun getById(@PathVariable id: Long): ResponseEntity<KYC> =
-        ResponseEntity.ok(service.getById(id) ?: throw IllegalArgumentException("KYC not found"))
-
-    @PreAuthorize("hasAnyRole('USER','ADMIN')")
+    @PreAuthorize("hasRole('USER','ADMIN')")
     @GetMapping("/user")
     fun getByUserId(principal: Principal): ResponseEntity<KYC> {
         val user = userRepository.findByEmail(principal.name)

--- a/src/main/kotlin/com/cornerstone/cheque/controller/PaymentLinkController.kt
+++ b/src/main/kotlin/com/cornerstone/cheque/controller/PaymentLinkController.kt
@@ -1,32 +1,23 @@
 package com.cornerstone.cheque.controller
 
 import com.cornerstone.cheque.model.PaymentLinkRequest
-import com.cornerstone.cheque.service.*
+import com.cornerstone.cheque.service.PaymentLinkService
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
-import java.math.BigDecimal
 import java.security.Principal
 
-@PreAuthorize("hasRole('ADMIN')")
 @RestController
 @RequestMapping("/api/payment-links")
 class PaymentLinkController(
     private val service: PaymentLinkService
 ) {
-    @GetMapping("/getAll")
-    fun getAll() = ResponseEntity.ok(service.getAll().map { service.toResponse(it) })
-
-    @GetMapping("/{id}")
-    fun getById(@PathVariable id: Long): ResponseEntity<PaymentLinkResponse> =
-        ResponseEntity.ok(service.getResponseById(id))
-
-    @PreAuthorize("hasAnyRole('USER','ADMIN')")
+    @PreAuthorize("hasRole('USER','ADMIN')")
     @PostMapping
     fun create(@RequestBody request: PaymentLinkRequest, principal: Principal): ResponseEntity<PaymentLinkResponse> =
         ResponseEntity.ok(service.toResponse(service.create(request, principal.name)))
 
-    @PreAuthorize("hasAnyRole('USER','ADMIN')")
+    @PreAuthorize("hasRole('USER','ADMIN')")
     @PostMapping("/use/{uuid}")
     fun use(@PathVariable uuid: String, principal: Principal): ResponseEntity<Any> {
         return try {
@@ -36,21 +27,4 @@ class PaymentLinkController(
             ResponseEntity.status(400).body(mapOf("error" to e.message))
         }
     }
-    @DeleteMapping("/{id}")
-    fun delete(@PathVariable id: Long): ResponseEntity<Void> {
-        service.delete(id)
-        return ResponseEntity.noContent().build()
-    }
 }
-
-
-data class PaymentLinkResponse(
-    val id: Long,
-    val accountNumber: String,
-    val amount: BigDecimal,
-    val description: String,
-    val status: String,
-    val transactionId: Long?,
-    val uuid: String
-)
-

--- a/src/main/kotlin/com/cornerstone/cheque/controller/RedeemCodeController.kt
+++ b/src/main/kotlin/com/cornerstone/cheque/controller/RedeemCodeController.kt
@@ -1,17 +1,10 @@
 package com.cornerstone.cheque.controller
 
 import com.cornerstone.cheque.service.RedeemService
-import jakarta.validation.constraints.NotNull
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
-import java.math.BigDecimal
 import java.security.Principal
-
-data class RedeemRequest(
-    @NotNull
-    val amount: BigDecimal
-)
 
 @RestController
 @RequestMapping("/api/redeem")
@@ -19,14 +12,7 @@ class RedeemController(
     private val redeemService: RedeemService
 ) {
 
-    @PreAuthorize("hasAnyRole('ADMIN')")
-    @PostMapping("/generate")
-    fun generateCode(@RequestBody request: RedeemRequest): ResponseEntity<Any> {
-        val code = redeemService.generate(request.amount)
-        return ResponseEntity.ok(mapOf("code" to code.code, "amount" to code.amount))
-    }
-
-    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+    @PreAuthorize("hasRole('USER,'ADMIN')")
     @PostMapping("/use/{code}")
     fun useCode(@PathVariable code: String, principal: Principal): ResponseEntity<Any> {
         val message = redeemService.redeem(code, principal.name)

--- a/src/main/kotlin/com/cornerstone/cheque/controller/TransactionController.kt
+++ b/src/main/kotlin/com/cornerstone/cheque/controller/TransactionController.kt
@@ -1,23 +1,16 @@
 package com.cornerstone.cheque.controller
 
-import com.cornerstone.cheque.model.Account
 import com.cornerstone.cheque.model.AccountResponse
-import com.cornerstone.cheque.model.Transaction
-import com.cornerstone.cheque.model.TransactionRequest
-import com.cornerstone.cheque.repo.AccountRepository
-import com.cornerstone.cheque.service.TransactionService
-import com.cornerstone.cheque.model.AccountType
 import com.cornerstone.cheque.model.DepositRequest
-import com.cornerstone.cheque.model.TransactionResponse
 import com.cornerstone.cheque.service.AccountService
+import com.cornerstone.cheque.service.TransactionService
 import com.cornerstone.cheque.service.UserService
+import com.cornerstone.cheque.repo.AccountRepository
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
 import java.security.Principal
-import java.time.LocalDateTime
 
-@PreAuthorize("hasRole('ADMIN')")
 @RestController
 @RequestMapping("/api/transactions")
 class TransactionController(
@@ -26,23 +19,11 @@ class TransactionController(
     private val userService: UserService,
     private val accountService: AccountService
 ) {
-    @GetMapping("/getAll")
-    fun getAll(): ResponseEntity<List<TransactionResponse>> =
-        ResponseEntity.ok(service.getAll().map {
-            TransactionResponse(
-                id = it.id,
-                senderAccountNumber = it.senderAccount.accountNumber,
-                receiverAccountNumber = it.receiverAccount.accountNumber,
-                amount = it.amount,
-                createdAt = it.createdAt
 
-            )
-        })
-
+    @PreAuthorize("hasRole('USER','ADMIN')")
     @PostMapping("/deposit")
-    @PreAuthorize("hasAnyRole('USER','ADMIN')")
     fun deposit(@RequestBody request: DepositRequest, principal: Principal): ResponseEntity<AccountResponse> {
-        val user = userService.findByUsername(principal.name)
+        val user = userService.findByEmail(principal.name)
             ?: throw IllegalStateException("User not authenticated")
 
         val account = accountService.getByUserId(user.email).firstOrNull()
@@ -51,11 +32,11 @@ class TransactionController(
         val updated = service.deposit(request.amount, accountRepository.findByAccountNumber(account.accountNumber)!!)
         return ResponseEntity.ok(accountService.getByAccountNumber(updated.accountNumber))
     }
-    // comment for azure
+
+    @PreAuthorize("hasRole('USER','ADMIN')")
     @PostMapping("/withdraw")
-    @PreAuthorize("hasAnyRole('USER','ADMIN')")
     fun withdraw(@RequestBody request: DepositRequest, principal: Principal): ResponseEntity<AccountResponse> {
-        val user = userService.findByUsername(principal.name)
+        val user = userService.findByEmail(principal.name)
             ?: throw IllegalStateException("User not authenticated")
 
         val account = accountService.getByUserId(user.email).firstOrNull()
@@ -64,5 +45,4 @@ class TransactionController(
         val updated = service.withdraw(request.amount, accountRepository.findByAccountNumber(account.accountNumber)!!)
         return ResponseEntity.ok(accountService.getByAccountNumber(updated.accountNumber))
     }
-
 }

--- a/src/main/kotlin/com/cornerstone/cheque/controller/TransferController.kt
+++ b/src/main/kotlin/com/cornerstone/cheque/controller/TransferController.kt
@@ -8,42 +8,19 @@ import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
 import java.security.Principal
 
-@PreAuthorize("hasRole('ADMIN')")
 @RestController
 @RequestMapping("/api/transfer")
 class TransferController(private val invoiceService: TransferService) {
 
-    @PreAuthorize("hasAnyRole('USER','ADMIN')")
+    @PreAuthorize("hasRole('USER','ADMIN')")
     @PostMapping
     fun create(@RequestBody request: TransferRequest, principal: Principal): ResponseEntity<Any> {
         val response = invoiceService.create(request, principal.name)
         return ResponseEntity.ok(response)
     }
 
-    @GetMapping("/{id}")
-    fun getInvoiceById(@PathVariable id: Long): ResponseEntity<TransferResponse> {
-        val invoice = invoiceService.getById(id) ?: throw IllegalArgumentException("Invoice not found")
-        return ResponseEntity.ok(invoice)
-    }
-
-    @GetMapping("/getAll")
-    fun getAllInvoices(): ResponseEntity<List<TransferResponse>> =
-        ResponseEntity.ok(invoiceService.getAll())
-
-    @GetMapping("/user/{userId}")
-    fun getByUserId(@PathVariable userId: Long): ResponseEntity<List<TransferResponse>> =
-        ResponseEntity.ok(invoiceService.getByUserId(userId))
-
-    @PreAuthorize("hasAnyRole('USER','ADMIN')")
+    @PreAuthorize("hasRole('USER','ADMIN')")
     @GetMapping("/my")
     fun getMyInvoices(principal: Principal): ResponseEntity<List<TransferResponse>> =
         ResponseEntity.ok(invoiceService.getMyInvoices(principal.name))
-
-    @GetMapping("/transaction/{transactionId}")
-    fun getByTransactionId(@PathVariable transactionId: Long): ResponseEntity<List<TransferResponse>> =
-        ResponseEntity.ok(invoiceService.getByTransactionId(transactionId))
-
-    @GetMapping("/account/{accountNumber}")
-    fun getByAccountNumber(@PathVariable accountNumber: String): ResponseEntity<List<TransferResponse>> =
-        ResponseEntity.ok(invoiceService.getByAccountNumber(accountNumber))
 }

--- a/src/main/kotlin/com/cornerstone/cheque/controller/UserController.kt
+++ b/src/main/kotlin/com/cornerstone/cheque/controller/UserController.kt
@@ -1,11 +1,11 @@
 package com.cornerstone.cheque.controller
 
+import com.cornerstone.cheque.model.Role
 import com.cornerstone.cheque.model.User
 import com.cornerstone.cheque.repo.UserRepository
 import com.cornerstone.cheque.service.UserService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.web.bind.annotation.*
 
@@ -23,18 +23,13 @@ class UserController(
             return ResponseEntity.status(HttpStatus.CONFLICT).body(mapOf("error" to "Email already exists"))
         }
         val hashedPassword = passwordEncoder.encode(entity.password)
-        val newUser = entity.copy(password = hashedPassword)
+        val newUser = User(
+            email = entity.email,
+            password = hashedPassword,
+            role = Role.USER,
+            status = "Active",
+            joinedDate = entity.joinedDate
+        )
         return ResponseEntity.ok(service.create(newUser))
-    }
-
-    @PreAuthorize("hasRole('ADMIN')")
-    @GetMapping("/users")
-    fun getAll(): ResponseEntity<List<User>> = ResponseEntity.ok(service.getAll())
-
-    @PreAuthorize("hasRole('ADMIN')")
-    @GetMapping("/users/{id}")
-    fun getById(@PathVariable id: Long): ResponseEntity<User> {
-        val result = service.getById(id) ?: throw IllegalArgumentException("User not found")
-        return ResponseEntity.ok(result)
     }
 }

--- a/src/main/kotlin/com/cornerstone/cheque/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/cornerstone/cheque/exception/GlobalExceptionHandler.kt
@@ -9,23 +9,17 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 class GlobalExceptionHandler {
 
     @ExceptionHandler(IllegalArgumentException::class)
-    fun handleIllegalArgument(ex: IllegalArgumentException): ResponseEntity<Map<String, String>> {
-        return ResponseEntity
-            .badRequest()
-            .body(mapOf("error" to (ex.message ?: "Bad request")))
+    fun handleIllegalArgumentException(e: IllegalArgumentException): ResponseEntity<String> {
+        return ResponseEntity(e.message, HttpStatus.BAD_REQUEST)
     }
 
     @ExceptionHandler(IllegalStateException::class)
-    fun handleIllegalState(ex: IllegalStateException): ResponseEntity<Map<String, String>> {
-        return ResponseEntity
-            .status(HttpStatus.CONFLICT)
-            .body(mapOf("error" to (ex.message ?: "Conflict")))
+    fun handleIllegalStateException(e: IllegalStateException): ResponseEntity<String> {
+        return ResponseEntity(e.message, HttpStatus.CONFLICT)
     }
 
     @ExceptionHandler(Exception::class)
-    fun handleGeneral(ex: Exception): ResponseEntity<Map<String, String>> {
-        return ResponseEntity
-            .status(HttpStatus.INTERNAL_SERVER_ERROR)
-            .body(mapOf("error" to "Unexpected error", "details" to (ex.message ?: "Unknown")))
+    fun handleGeneralException(e: Exception): ResponseEntity<String> {
+        return ResponseEntity("An error occurred: ${e.message}", HttpStatus.INTERNAL_SERVER_ERROR)
     }
 }

--- a/src/main/kotlin/com/cornerstone/cheque/model/User.kt
+++ b/src/main/kotlin/com/cornerstone/cheque/model/User.kt
@@ -1,6 +1,7 @@
 package com.cornerstone.cheque.model
 
 import jakarta.persistence.*
+import java.time.LocalDateTime
 
 @Entity
 @Table(name = "users")
@@ -11,7 +12,16 @@ data class User(
     var email: String= "",
     var password: String = "",
     @Enumerated(EnumType.STRING)
-    var role: Role = Role.USER
+
+    @Column(nullable = false)
+    var role: Role = Role.USER,
+
+    @Column(nullable = false)
+    var status: String = "Active",
+
+    @Column(nullable = false)
+    val joinedDate: LocalDateTime = LocalDateTime.now()
+
     )
 enum class Role {
     USER,ADMIN

--- a/src/main/kotlin/com/cornerstone/cheque/repo/RedeemCodeRepository.kt
+++ b/src/main/kotlin/com/cornerstone/cheque/repo/RedeemCodeRepository.kt
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository
 @Repository
 interface RedeemCodeRepository : JpaRepository<RedeemCode, Long> {
     fun findByCode(code: String): RedeemCode?
+    fun countByUsedFalse(): Long
 }

--- a/src/main/kotlin/com/cornerstone/cheque/repo/TransactionRepository.kt
+++ b/src/main/kotlin/com/cornerstone/cheque/repo/TransactionRepository.kt
@@ -2,7 +2,11 @@ package com.cornerstone.cheque.repo
 
 import com.cornerstone.cheque.model.Transaction
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 
 @Repository
-interface TransactionRepository : JpaRepository<Transaction, Long>
+interface TransactionRepository : JpaRepository<Transaction, Long> {
+    @Query("SELECT SUM(t.amount) FROM Transaction t")
+    fun getTotalTransactionAmount(): Int?
+}

--- a/src/main/kotlin/com/cornerstone/cheque/repo/UserRepository.kt
+++ b/src/main/kotlin/com/cornerstone/cheque/repo/UserRepository.kt
@@ -1,11 +1,14 @@
 package com.cornerstone.cheque.repo
 
+import com.cornerstone.cheque.model.Role
 import com.cornerstone.cheque.model.User
+import org.hibernate.mapping.List
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
 interface UserRepository : JpaRepository<User, Long> {
     fun findByEmail(email: String): User?
-}
+    fun findByRole(role: Role, pageable: PageRequest): List}
 

--- a/src/main/kotlin/com/cornerstone/cheque/service/RedeemCodeService.kt
+++ b/src/main/kotlin/com/cornerstone/cheque/service/RedeemCodeService.kt
@@ -52,4 +52,7 @@ class RedeemService(
 
         return "Balance updated by ${redeemCode.amount}. New balance: ${account.balance}"
     }
+    fun countActiveCodes(): Long {
+        return redeemCodeRepository.countByUsedFalse()
+    }
 }

--- a/src/main/kotlin/com/cornerstone/cheque/service/TransactionService.kt
+++ b/src/main/kotlin/com/cornerstone/cheque/service/TransactionService.kt
@@ -12,16 +12,16 @@ import java.time.LocalDateTime
 
 @Service
 class TransactionService(
-    private val repository: TransactionRepository,
+    private val transactionRepository: TransactionRepository,
     private val accountRepository: AccountRepository) {
 
 
 
     fun getById(id: Long): Transaction? =
-        repository.findById(id).orElse(null)
+        transactionRepository.findById(id).orElse(null)
 
     fun getAll(): List<Transaction> =
-        repository.findAll()
+        transactionRepository.findAll()
 
     fun deposit(amount: BigDecimal, account: Account): Account {
         account.balance += amount
@@ -34,12 +34,16 @@ class TransactionService(
         return accountRepository.save(account)
     }
 
+    fun getTotalTransactionAmount(): Int {
+        return transactionRepository.getTotalTransactionAmount() ?: 0
+    }
+
 
     fun getByAccountNumber(accountNumber: String): List<TransactionResponse> {
         val account = accountRepository.findByAccountNumber(accountNumber)
             ?: throw IllegalArgumentException("Account not found")
 
-        return repository.findAll()
+        return transactionRepository.findAll()
             .filter {
                 (it.senderAccount?.accountNumber == account.accountNumber) ||
                         (it.receiverAccount?.accountNumber == account.accountNumber)

--- a/src/main/kotlin/com/cornerstone/cheque/service/UserService.kt
+++ b/src/main/kotlin/com/cornerstone/cheque/service/UserService.kt
@@ -1,19 +1,61 @@
 package com.cornerstone.cheque.service
 
-import com.cornerstone.cheque.repo.UserRepository
-import org.springframework.stereotype.Service
+import com.cornerstone.cheque.model.Role
 import com.cornerstone.cheque.model.User
+import com.cornerstone.cheque.repo.UserRepository
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+import java.util.*
 
 @Service
-class UserService(private val repository: UserRepository) {
-    fun findByUsername(username: String): User? {
-        return repository.findByEmail(username)
+class UserService(private val userRepository: UserRepository) {
+
+    fun create(user: User): User {
+        return userRepository.save(user)
     }
 
-    fun create (entity: User): User = repository.save(entity)
+    fun getAll(): List<User> {
+        return userRepository.findAll()
+    }
 
-    fun getById (id: Long): User = repository.findById(id).orElse(null)
+    fun findByEmail(email: String): User? {
+        return userRepository.findByEmail(email)
+    }
 
-    fun getAll(): List<User> = repository.findAll()
+    fun getTotalUsers(): Long {
+        return userRepository.count()
+    }
+
+    fun getUsers(page: Int, size: Int, role: String?): Any {
+        val pageable = PageRequest.of(page, size)
+        return if (role != null) {
+            userRepository.findByRole(Role.valueOf(role.uppercase()), pageable)
+        } else {
+            userRepository.findAll(pageable).content
+        }
+    }
+
+    fun getUserById(userId: Long): User {
+        return userRepository.findById(userId)
+            .orElseThrow { IllegalArgumentException("User not found") }
+    }
+
+    fun deleteUser(userId: Long) {
+        userRepository.deleteById(userId)
+    }
+
+    fun resetPassword(userId: Long): String {
+        val user = getUserById(userId)
+        val newPassword = UUID.randomUUID().toString().substring(0, 8)
+        user.password = newPassword // In production, hash the password
+        userRepository.save(user)
+        return newPassword
+    }
+
+    fun suspendUser(userId: Long) {
+        val user = getUserById(userId)
+        user.status = if (user.status == "Active") "Suspended" else "Active"
+        userRepository.save(user)
+    }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,4 +9,4 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.show-sql=true
 logging.level.org.springframework=INFO
-server.port=8081
+server.port=8080


### PR DESCRIPTION
- Moved all admin-specific endpoints to AdminController
- Removed admin endpoints from:
  - AccountController
  - KYCController
  - PaymentLinkController
  - RedeemController
  - TransactionController
  - TransferController
  - UserController
- Scoped remaining endpoints with appropriate user-level access (`hasRole('USER')`)
- Ensured cleaner, role-specific controller architecture for better maintainability and security